### PR TITLE
style: right-align social media icons in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -35,7 +35,7 @@ import Default from '@astrojs/starlight/components/Footer.astro';
 <style>
   .social-links {
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     align-items: center;
     gap: 1.25rem;
     padding: 1rem 0 0.5rem;


### PR DESCRIPTION
Align social media links to the right edge of the footer.

**Changes:**
- Modified `src/components/Footer.astro`
- Changed `.social-links` CSS from `justify-content: center;` to `justify-content: flex-end;`

**Closes #30**