### PR TITLE
style: add theme-adaptive border to terminal frames

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -56,6 +56,14 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* macOS iTerm-style window frame for terminal code blocks */
+.expressive-code .frame.is-terminal {
+  border: 2px solid rgba(255, 255, 255, 0.15);
+}
+
+:root[data-theme="light"] .expressive-code .frame.is-terminal {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
 .expressive-code .frame.is-terminal .header {
   padding-block: 0.25rem;
   border: none;


### PR DESCRIPTION
Closes #44

Add 2px semi-transparent borders to terminal code block frames with theme-aware colors for improved visual definition.