### PR TITLE
Remove 'build' required status check

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -41,7 +41,7 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["Check linked issues", "build"]
+        "contexts": ["Check linked issues"]
       },
       "required_pull_request_reviews": {
         "required_approving_review_count": 0,


### PR DESCRIPTION
## Summary
- Remove `build` from required status checks in `repo-settings.json`
- The content-only repo delegates building to the reusable workflow in `f5xc-docs-builder`, which only runs on push to `main` — no build job runs on PRs

## Test plan
- [ ] Verify PR merges without the `build` check blocking
- [ ] Verify the enforce-repo-settings workflow applies the updated config

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)