### PR TITLE
feat: migrate to centralized repo settings enforcement

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -1,62 +1,7 @@
 {
-  "owner": "robinmordasiewicz",
-  "repo": "f5xc-ddos-administration-guide",
   "repository": {
     "description": "F5 XC DDoS Administration Guide",
-    "homepage": "https://robinmordasiewicz.github.io/f5xc-ddos-administration-guide/",
-    "private": false,
-    "has_issues": true,
-    "has_projects": false,
-    "has_wiki": false,
-    "is_template": false,
-    "allow_squash_merge": true,
-    "allow_merge_commit": true,
-    "allow_rebase_merge": true,
-    "allow_auto_merge": true,
-    "delete_branch_on_merge": true,
-    "web_commit_signoff_required": false,
-    "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
-    "squash_merge_commit_message": "COMMIT_MESSAGES",
-    "merge_commit_title": "MERGE_MESSAGE",
-    "merge_commit_message": "PR_TITLE",
-    "allow_update_branch": true
+    "homepage": "https://robinmordasiewicz.github.io/f5xc-ddos-administration-guide/"
   },
-  "actions_permissions": {
-    "default_workflow_permissions": "write",
-    "can_approve_pull_request_reviews": true
-  },
-  "pages": {
-    "build_type": "workflow",
-    "source": {
-      "branch": "main",
-      "path": "/"
-    }
-  },
-  "topics": {
-    "names": ["ddos", "manual"]
-  },
-  "branch_protection": [
-    {
-      "branch": "main",
-      "enforce_admins": true,
-      "required_status_checks": {
-        "strict": false,
-        "contexts": ["Check linked issues"]
-      },
-      "required_pull_request_reviews": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews": false,
-        "require_code_owner_reviews": false,
-        "require_last_push_approval": false
-      },
-      "restrictions": null,
-      "required_linear_history": false,
-      "allow_force_pushes": false,
-      "allow_deletions": false,
-      "block_creations": false,
-      "required_conversation_resolution": false,
-      "lock_branch": false,
-      "allow_fork_syncing": false
-    }
-  ]
+  "topics": ["ddos", "manual"]
 }

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -7,7 +7,6 @@ on:
     branches: [main]
     paths:
       - '.github/config/repo-settings.json'
-      - 'scripts/configure-repo.sh'
   workflow_dispatch:
 
 permissions:
@@ -15,14 +14,6 @@ permissions:
 
 jobs:
   enforce:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Enforce repo settings
-        env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
-        run: |
-          chmod +x scripts/configure-repo.sh
-          ./scripts/configure-repo.sh
+    uses: robinmordasiewicz/f5xc-docs-builder/.github/workflows/enforce-repo-settings.yml@main
+    secrets:
+      repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
## Summary

Replace the broken local `enforce-repo-settings.yml` workflow (which references the deleted `scripts/configure-repo.sh`) with a thin caller to the centralized reusable workflow in `f5xc-docs-builder`. Slim `repo-settings.json` to per-repo overrides only.

## Related Issue

Closes #59

## Changes

- `.github/workflows/enforce-repo-settings.yml` — replaced inline script-based job with `workflow_call` to `robinmordasiewicz/f5xc-docs-builder/.github/workflows/enforce-repo-settings.yml@main`
- `.github/config/repo-settings.json` — removed universal defaults (now baked into the reusable workflow), kept only per-repo overrides: `description`, `homepage`, `topics`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions