### PR TITLE
fix: update reusable workflow references from f5xc-docs-builder to f5xc-template

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,4 +15,4 @@ concurrency:
 
 jobs:
   docs:
-    uses: robinmordasiewicz/f5xc-docs-builder/.github/workflows/docs-build-deploy.yml@main
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/docs-build-deploy.yml@main

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   enforce:
-    uses: robinmordasiewicz/f5xc-docs-builder/.github/workflows/enforce-repo-settings.yml@main
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings-reusable.yml@main
     secrets:
       repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
Closes #61

The reusable workflows were moved from f5xc-docs-builder to f5xc-template. This PR updates all downstream caller references to point to the new template repository.

## Changes
- **deploy.yml**: Updated docs-build-deploy.yml reference to use f5xc-template
- **enforce-repo-settings.yml**: Updated enforce-repo-settings-reusable.yml reference to use f5xc-template

## Impact
- Fixes broken CI/CD pipeline for docs deployment
- Fixes broken repository settings enforcement workflow
- Aligns with centralized governance workflow architecture