### PR TITLE
fix: rename deploy.yml to github-pages-deploy.yml

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs
+name: GitHub Pages Deploy
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

- Rename `.github/workflows/deploy.yml` → `github-pages-deploy.yml` with updated `name:` field (`GitHub Pages Deploy`)

## Test plan

- [ ] Verify `github-pages-deploy.yml` exists and `deploy.yml` is gone
- [ ] After merge, push a docs change and confirm the "GitHub Pages Deploy" workflow runs
- [ ] Confirm no orphaned "Deploy Docs" workflow in Actions tab

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)